### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -27,7 +27,7 @@ pin_read	KEYWORD2
 setDebounceTime	KEYWORD2
 setHoldTime	KEYWORD2
 waitForKey	KEYWORD2
-addTransitionListener KEYWORD2
+addTransitionListener	KEYWORD2
 
 # this is a macro that converts 2d arrays to pointers
 makeKeymap	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords